### PR TITLE
remove reference to no_llseek fops removed in linux 6.12

### DIFF
--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -398,7 +398,6 @@ static long  pn54x_dev_ioctl(struct file *filp, unsigned int cmd,
 
 static const struct file_operations pn54x_dev_fops = {
 	.owner	= THIS_MODULE,
-	.llseek	= no_llseek,
 	.read	= pn54x_dev_read,
 	.write	= pn54x_dev_write,
 	.open	= pn54x_dev_open,


### PR DESCRIPTION
Fix compilation on linux >= 6.12