### PR TITLE
Migrate to gpiod API for Linux 7.1 + bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # nxp-pn5xx
-This is a fork of NXP's NFC Open Source Kernel mode driver that adds support for ACPI. Linux kernel **>= 3.17** is required.
 
-As of mid-2018, many ThinkPad models include the NXP NPC300 chip for NFC. Although valid ACPI information is made available, the official driver does unfortunately not make use of it so the device does not work.
+Kernel driver for the NXP NPC300 NFC chip found in many ThinkPad models (T470, T480, T480s, X280, X1 Carbon Gen 6+, X1 Yoga Gen 3, X1 Yoga Gen 8). Any model containing Lenovo part number **01AX745** should be supported. This is a fork of NXP's upstream pn5xx driver with added ACPI support for the `NXP1001` hardware ID used by Lenovo.
 
-Currently, this fork only supports the bare minimum of configuration to make the NFC chip work (IRQ pin and VEN pin). I tested it on a Thinkpad T480s running Ubuntu 18.04 with kernel 4.15. According to reports, at the very least the T470 and Carbon X1C should also be supported. However, this is still an unofficial modification so USE AT YOUR OWN RISK. If the GPIO pins are configured wrong, you can potentially damage other components attached to them.
+Requires Linux **≥ 3.17**.
 
-### Known issues
-On my device, the touchpad becomes slow and unprecise as soon as I use the NFC chip. If anyone has any ideas what could be causing this and how to fix it, please open an issue.
+## What it does
+
+Exposes the chip as `/dev/pn544`. GPIO configuration is sourced automatically from either ACPI (x86 ThinkPads) or a Device Tree node (embedded) - see `sample_devicetree.txt` for a DT example. The DT binding supports optional `firmware-gpios` and `clkreq-gpios` in addition to the required `interrupt-gpios` and `enable-gpios`.
+
+## Userland
+
+Use <https://github.com/StarGate01/linux_libnfc-nci> with the kernel driver (I2C mode). Build with `--enable-i2c` - that flag makes the HAL use `/dev/pn544` via this driver.
+
+## Known issues
+
+On some older models (T480s with Elan touchpad) the touchpad becomes laggy while the NFC driver is active. This is a conflict at the I2C bus level between the touchpad and NFC drivers, not a bug in this driver. Suspending and resuming the system restores normal touchpad behaviour.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # nxp-pn5xx
-This is a fork of NXP's NFC Open Source Kernel mode driver that adds support for ACPI.
-
+This is a fork of NXP's NFC Open Source Kernel mode driver that adds support for ACPI. Linux kernel **>= 3.17** is required.
 
 As of mid-2018, many ThinkPad models include the NXP NPC300 chip for NFC. Although valid ACPI information is made available, the official driver does unfortunately not make use of it so the device does not work.
 
-
 Currently, this fork only supports the bare minimum of configuration to make the NFC chip work (IRQ pin and VEN pin). I tested it on a Thinkpad T480s running Ubuntu 18.04 with kernel 4.15. According to reports, at the very least the T470 and Carbon X1C should also be supported. However, this is still an unofficial modification so USE AT YOUR OWN RISK. If the GPIO pins are configured wrong, you can potentially damage other components attached to them.
-
 
 ### Known issues
 On my device, the touchpad becomes slow and unprecise as soon as I use the NFC chip. If anyone has any ideas what could be causing this and how to fix it, please open an issue.

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -40,7 +40,6 @@
 #include <linux/version.h>
 
 #include <linux/of.h>
-#include <linux/of_gpio.h>
 #include <linux/acpi.h>
 
 #include "pn5xx_i2c.h"
@@ -417,76 +416,45 @@ static const struct file_operations pn54x_dev_fops = {
 static int pn54x_get_pdata_of(struct device *dev,
 							struct pn544_i2c_platform_data *pdata)
 {
-	struct device_node *node;
-	int val;
+	struct gpio_desc *desc;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,3,0)
-	u32 flags;
-#endif
-
-	/* make sure there is actually a device tree node */
-	node = dev->of_node;
-	if (!node)
+	if (!dev->of_node)
 		return -ENODEV;
 
 	memset(pdata, 0, sizeof(*pdata));
 
-	/* read the dev tree data */
-
 	/* ven pin - enable's power to the chip - REQUIRED */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,3,0)
-	val = of_get_named_gpio_flags(node, "enable-gpios", 0, &flags);
-#else
-	val = of_get_named_gpio(node, "enable-gpios", 0);
-#endif
-	if (val >= 0) {
-		pdata->ven_gpio = val;
-	}
-	else {
+	desc = devm_gpiod_get(dev, "enable", GPIOD_ASIS);
+	if (IS_ERR(desc)) {
 		dev_err(dev, "VEN GPIO error getting from OF node\n");
-		return val;
+		return PTR_ERR(desc);
 	}
+	pdata->ven_gpio = desc_to_gpio(desc);
 
 	/* firm pin - controls firmware download - OPTIONAL */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,3,0)
-	val = of_get_named_gpio_flags(node, "firmware-gpios", 0, &flags);
-#else
-	val = of_get_named_gpio(node, "firmware-gpios", 0);
-#endif
-	if (val >= 0) {
-		pdata->firm_gpio = val;
-	}
-	else {
+	desc = devm_gpiod_get_optional(dev, "firmware", GPIOD_ASIS);
+	if (IS_ERR(desc)) {
 		pdata->firm_gpio = GPIO_UNUSED;
 		dev_warn(dev, "FIRM GPIO <OPTIONAL> error getting from OF node\n");
+	} else {
+		pdata->firm_gpio = desc ? desc_to_gpio(desc) : GPIO_UNUSED;
 	}
 
 	/* irq pin - data available irq - REQUIRED */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,3,0)
-	val = of_get_named_gpio_flags(node, "interrupt-gpios", 0, &flags);
-#else
-	val = of_get_named_gpio(node, "interrupt-gpios", 0);
-#endif
-	if (val >= 0) {
-		pdata->irq_gpio = val;
-	}
-	else {
+	desc = devm_gpiod_get(dev, "interrupt", GPIOD_ASIS);
+	if (IS_ERR(desc)) {
 		dev_err(dev, "IRQ GPIO error getting from OF node\n");
-		return val;
+		return PTR_ERR(desc);
 	}
+	pdata->irq_gpio = desc_to_gpio(desc);
 
 	/* clkreq pin - controls the clock to the PN547 - OPTIONAL */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,3,0)
-	val = of_get_named_gpio_flags(node, "nxp,pn54x-clkreq", 0, &flags);
-#else
-	val = of_get_named_gpio(node, "nxp,pn54x-clkreq", 0);
-#endif
-	if (val >= 0) {
-		pdata->clkreq_gpio = val;
-	}
-	else {
+	desc = devm_gpiod_get_optional(dev, "clkreq", GPIOD_ASIS);
+	if (IS_ERR(desc)) {
 		pdata->clkreq_gpio = GPIO_UNUSED;
 		dev_warn(dev, "CLKREQ GPIO <OPTIONAL> error getting from OF node\n");
+	} else {
+		pdata->clkreq_gpio = desc ? desc_to_gpio(desc) : GPIO_UNUSED;
 	}
 
 	/* handle the regulator lines - these are optional

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -299,7 +299,7 @@ static ssize_t pn54x_dev_write(struct file *filp, const char __user *buf,
 	}
 
 	/* pn54x seems to be slow in handling I2C write requests
-	 * so add 1ms delay after I2C send oparation */
+	 * so add 1ms delay after I2C send operation */
 	udelay(1000);
 
 	return ret;

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -534,16 +534,16 @@ static int pn54x_get_pdata_acpi(struct device *dev,
 {
 	struct gpio_desc *irq_desc, *ven_desc;
 
-	/* ven pin - enable's power to the chip - REQUIRED */
+	/* irq pin - data available irq - REQUIRED (ACPI index 0: GpioInt) */
 	irq_desc = devm_gpiod_get_index(dev, NULL, 0, GPIOD_ASIS);
 	if (IS_ERR(irq_desc)) {
 		dev_err(dev, "IRQ GPIO error getting from ACPI\n");
 		return PTR_ERR(irq_desc);
-	} 
+	}
 	pdata->irq_gpio = desc_to_gpio(irq_desc);
 	pr_info("%s: request irq_gpio %d\n", __func__, pdata->irq_gpio);
 
-	/* irq pin - data available irq - REQUIRED */
+	/* ven pin - enable's power to the chip - REQUIRED (ACPI index 2: GpioIo, index 1 is firmware) */
 	ven_desc = devm_gpiod_get_index(dev, NULL, 2, GPIOD_ASIS);
 	if (IS_ERR(ven_desc)) {
 		dev_err(dev, "VEN GPIO error getting from ACPI\n");

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -321,14 +321,7 @@ static int pn54x_dev_open(struct inode *inode, struct file *filp)
 
 static int pn54x_dev_release(struct inode *inode, struct file *filp)
 {
-	// struct pn54x_dev *pn54x_dev = container_of(filp->private_data,
-	//										   struct pn54x_dev,
-	//										   pn54x_device);
-
 	pr_info("%s : closing %d,%d\n", __func__, imajor(inode), iminor(inode));
-
-	// pn544_disable(pn54x_dev);
-
 	return 0;
 }
 
@@ -353,18 +346,18 @@ static long  pn54x_dev_ioctl(struct file *filp, unsigned int cmd,
 		}
 		break;
 	case PN54X_CLK_REQ:
-		if(1 == arg){
+		if(CLK_ON == arg){
 			if(pn54x_dev->clkreq_gpio){
-				gpiod_set_value(pn54x_dev->clkreq_gpio, 1);
+				gpiod_set_value_cansleep(pn54x_dev->clkreq_gpio, 1);
 			}
 			else {
 				pr_err("%s Unused Clkreq GPIO %lu\n", __func__, arg);
 				return -EOPNOTSUPP;
 			}
 		}
-		else if(0 == arg) {
+		else if(CLK_OFF == arg) {
 			if(pn54x_dev->clkreq_gpio){
-				gpiod_set_value(pn54x_dev->clkreq_gpio, 0);
+				gpiod_set_value_cansleep(pn54x_dev->clkreq_gpio, 0);
 			}
 			else {
 				pr_err("%s Unused Clkreq GPIO %lu\n", __func__, arg);
@@ -532,14 +525,13 @@ static int pn54x_probe(struct i2c_client *client)
 #endif
 {
 	int ret = 0;
-	struct pn544_i2c_platform_data *pdata; // gpio values, from board file or DT
+	struct pn544_i2c_platform_data *pdata;
 	struct pn544_i2c_platform_data tmp_pdata;
-	struct pn54x_dev *pn54x_dev; // internal device specific data
+	struct pn54x_dev *pn54x_dev;
+	bool is_acpi = false;
 
 	pr_info("%s\n", __func__);
 
-	// If the dev.platform_data is NULL, then attempt to read from ACPI first, then the device tree
-	bool is_acpi = false;
 	pdata = client->dev.platform_data;
 
 	if(!pdata)
@@ -552,7 +544,7 @@ static int pn54x_probe(struct i2c_client *client)
 		}
 #endif
 #ifdef CONFIG_OF
-		// If device was not configured via ACPI, or ACPI configuration failed
+		/* if device was not configured via ACPI, or ACPI configuration failed */
 		if ((!is_acpi || ret) && client->dev.of_node) {
 			pr_info("%s: configuring via device tree\n", __func__);
 			ret = pn54x_get_pdata_of(&(client->dev), &tmp_pdata);

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -498,16 +498,21 @@ static int pn54x_get_pdata_acpi(struct device *dev,
 	}
 	pdata->irq_gpio = desc;
 
-	/* ven pin - enable's power to the chip - REQUIRED (ACPI index 2: GpioIo, index 1 is firmware) */
+	/* firm pin - controls firmware download - REQUIRED (ACPI index 1: GpioIo) */
+	desc = devm_gpiod_get_index(dev, NULL, 1, GPIOD_OUT_LOW);
+	if (IS_ERR(desc)) {
+		dev_err(dev, "FIRM GPIO error getting from ACPI\n");
+		return PTR_ERR(desc);
+	}
+	pdata->firm_gpio = desc;
+
+	/* ven pin - enable's power to the chip - REQUIRED (ACPI index 2: GpioIo) */
 	desc = devm_gpiod_get_index(dev, NULL, 2, GPIOD_OUT_LOW);
 	if (IS_ERR(desc)) {
 		dev_err(dev, "VEN GPIO error getting from ACPI\n");
 		return PTR_ERR(desc);
 	}
 	pdata->ven_gpio = desc;
-
-	/* firm pin - controls firmware download - OPTIONAL */
-	pdata->firm_gpio = NULL;
 
 	/* clkreq pin - controls the clock to the PN547 - OPTIONAL */
 	pdata->clkreq_gpio = NULL;

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -23,15 +23,11 @@
 #include <linux/fs.h>
 #include <linux/slab.h>
 #include <linux/init.h>
-#include <linux/list.h>
 #include <linux/i2c.h>
 #include <linux/irq.h>
-#include <linux/jiffies.h>
 #include <linux/uaccess.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/io.h>
-#include <linux/platform_device.h>
 #include <linux/gpio/consumer.h>
 #include <linux/miscdevice.h>
 #include <linux/spinlock.h>
@@ -674,9 +670,6 @@ static void pn54x_remove(struct i2c_client *client)
 #endif
 }
 
-/*
- *
- */
 #ifdef CONFIG_OF
 static struct of_device_id pn54x_dt_match[] = {
 	{ .compatible = "nxp,pn547", },

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -492,31 +492,29 @@ static int pn54x_get_pdata_of(struct device *dev,
 static int pn54x_get_pdata_acpi(struct device *dev,
 							struct pn544_i2c_platform_data *pdata)
 {
-	struct gpio_desc *irq_desc, *ven_desc;
+	struct gpio_desc *desc;
 
 	/* irq pin - data available irq - REQUIRED (ACPI index 0: GpioInt) */
-	irq_desc = devm_gpiod_get_index(dev, NULL, 0, GPIOD_ASIS);
-	if (IS_ERR(irq_desc)) {
+	desc = devm_gpiod_get_index(dev, NULL, 0, GPIOD_IN);
+	if (IS_ERR(desc)) {
 		dev_err(dev, "IRQ GPIO error getting from ACPI\n");
-		return PTR_ERR(irq_desc);
+		return PTR_ERR(desc);
 	}
-	pdata->irq_gpio = desc_to_gpio(irq_desc);
-	pr_info("%s: request irq_gpio %d\n", __func__, pdata->irq_gpio);
+	pdata->irq_gpio = desc;
 
 	/* ven pin - enable's power to the chip - REQUIRED (ACPI index 2: GpioIo, index 1 is firmware) */
-	ven_desc = devm_gpiod_get_index(dev, NULL, 2, GPIOD_ASIS);
-	if (IS_ERR(ven_desc)) {
+	desc = devm_gpiod_get_index(dev, NULL, 2, GPIOD_OUT_LOW);
+	if (IS_ERR(desc)) {
 		dev_err(dev, "VEN GPIO error getting from ACPI\n");
-		return PTR_ERR(ven_desc);
+		return PTR_ERR(desc);
 	}
-	pdata->ven_gpio = desc_to_gpio(ven_desc);
-	pr_info("%s: request ven_gpio %d\n", __func__, pdata->ven_gpio);
+	pdata->ven_gpio = desc;
 
 	/* firm pin - controls firmware download - OPTIONAL */
-	pdata->firm_gpio = GPIO_UNUSED;
+	pdata->firm_gpio = NULL;
 
 	/* clkreq pin - controls the clock to the PN547 - OPTIONAL */
-	pdata->clkreq_gpio = GPIO_UNUSED;
+	pdata->clkreq_gpio = NULL;
 
 	pdata->pvdd_reg = NULL;
 	pdata->vbat_reg = NULL;
@@ -586,56 +584,19 @@ static int pn54x_probe(struct i2c_client *client)
 		return  -ENODEV;
 	}
 
-	/* if ACPI config is used, the GPIO pins are already reserved */
-	if(!is_acpi) {
-		/* reserve the GPIO pins */
-		pr_info("%s: request irq_gpio %d\n", __func__, pdata->irq_gpio);
-		ret = gpio_request(pdata->irq_gpio, "nfc_int");
-		if (ret){
-			pr_err("%s: not able to get GPIO irq_gpio\n", __func__);
-			return  -ENODEV;
-		}
-		ret = gpio_to_irq(pdata->irq_gpio);
-		if (ret < 0){
-			pr_err("%s: not able to map GPIO irq_gpio to an IRQ\n", __func__);
-			goto err_ven;
-		}
-		else{
-			client->irq = ret;
-		}
-
-		pr_info("%s: request ven_gpio %d\n", __func__, pdata->ven_gpio);
-		ret = gpio_request(pdata->ven_gpio, "nfc_ven");
-		if (ret){
-			pr_err("%s: not able to get GPIO ven_gpio\n", __func__);
-			goto err_ven;
-		}
-
-		if (gpio_is_valid(pdata->firm_gpio)) {
-			pr_info("%s: request firm_gpio %d\n", __func__, pdata->firm_gpio);
-			ret = gpio_request(pdata->firm_gpio, "nfc_firm");
-			if (ret){
-				pr_err("%s: not able to get GPIO firm_gpio\n", __func__);
-				goto err_firm;
-			}
-		}
-
-		if (gpio_is_valid(pdata->clkreq_gpio)) {
-			pr_info("%s: request clkreq_gpio %d\n", __func__, pdata->clkreq_gpio);
-			ret = gpio_request(pdata->clkreq_gpio, "nfc_clkreq");
-			if (ret){
-				pr_err("%s: not able to get GPIO clkreq_gpio\n", __func__);
-				goto err_clkreq;
-			}
-		}
+	/* map the IRQ GPIO to an IRQ number */
+	ret = gpiod_to_irq(pdata->irq_gpio);
+	if (ret < 0) {
+		pr_err("%s: not able to map irq_gpio to an IRQ\n", __func__);
+		return ret;
 	}
+	client->irq = ret;
 
 	/* allocate the pn54x driver information structure */
 	pn54x_dev = kzalloc(sizeof(*pn54x_dev), GFP_KERNEL);
 	if (pn54x_dev == NULL) {
 		dev_err(&client->dev, "failed to allocate memory for module data\n");
-		ret = -ENOMEM;
-		goto err_exit;
+		return -ENOMEM;
 	}
 
 	/* store the platform data in the driver info struct */
@@ -685,19 +646,7 @@ static int pn54x_probe(struct i2c_client *client)
 err_request_irq_failed:
 	misc_deregister(&pn54x_dev->pn54x_device);
 err_misc_register:
-err_exit:
-	if (gpio_is_valid(pdata->clkreq_gpio))
-		gpio_free(pdata->clkreq_gpio);
-
-	if(!is_acpi) {
-err_clkreq:
-		if (gpio_is_valid(pdata->firm_gpio))
-			gpio_free(pdata->firm_gpio);
-err_firm:
-		gpio_free(pdata->ven_gpio);
-err_ven:
-		gpio_free(pdata->irq_gpio);
-	}
+	kfree(pn54x_dev);
 
 	return ret;
 }
@@ -718,17 +667,6 @@ static void pn54x_remove(struct i2c_client *client)
 	free_irq(client->irq, pn54x_dev);
 	misc_deregister(&pn54x_dev->pn54x_device);
 	mutex_destroy(&pn54x_dev->read_mutex);
-	gpio_free(pn54x_dev->irq_gpio);
-	gpio_free(pn54x_dev->ven_gpio);
-	if (gpio_is_valid(pn54x_dev->firm_gpio))
-		gpio_free(pn54x_dev->firm_gpio);
-	if (gpio_is_valid(pn54x_dev->clkreq_gpio))
-		gpio_free(pn54x_dev->clkreq_gpio);
-	regulator_put(pn54x_dev->pvdd_reg);
-	regulator_put(pn54x_dev->vbat_reg);
-	regulator_put(pn54x_dev->pmuvcc_reg);
-	regulator_put(pn54x_dev->sevdd_reg);
-
 	kfree(pn54x_dev);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -377,12 +377,13 @@ static long  pn54x_dev_ioctl(struct file *filp, unsigned int cmd,
 }
 
 static const struct file_operations pn54x_dev_fops = {
-	.owner	= THIS_MODULE,
-	.read	= pn54x_dev_read,
-	.write	= pn54x_dev_write,
-	.open	= pn54x_dev_open,
-	.release  = pn54x_dev_release,
-	.unlocked_ioctl  = pn54x_dev_ioctl,
+	.owner		= THIS_MODULE,
+	.read		= pn54x_dev_read,
+	.write		= pn54x_dev_write,
+	.open		= pn54x_dev_open,
+	.release	= pn54x_dev_release,
+	.unlocked_ioctl	= pn54x_dev_ioctl,
+	.compat_ioctl	= pn54x_dev_ioctl,
 };
 
 

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -32,7 +32,7 @@
 #include <linux/interrupt.h>
 #include <linux/io.h>
 #include <linux/platform_device.h>
-#include <linux/gpio.h>
+#include <linux/gpio/consumer.h>
 #include <linux/miscdevice.h>
 #include <linux/spinlock.h>
 #include <linux/regulator/consumer.h>
@@ -61,10 +61,10 @@ struct pn54x_dev	{
 	struct mutex read_mutex;
 	struct i2c_client *client;
 	struct miscdevice pn54x_device;
-	int ven_gpio;
-	int firm_gpio;
-	int irq_gpio;
-	int clkreq_gpio;
+	struct gpio_desc *ven_gpio;
+	struct gpio_desc *firm_gpio;
+	struct gpio_desc *irq_gpio;
+	struct gpio_desc *clkreq_gpio;
 	struct regulator *pvdd_reg;
 	struct regulator *vbat_reg;
 	struct regulator *pmuvcc_reg;
@@ -144,28 +144,28 @@ static int pn544_enable(struct pn54x_dev *dev, int mode)
 
 	if (MODE_RUN == mode) {
 		pr_info("%s power on\n", __func__);
-		if (gpio_is_valid(dev->firm_gpio))
-			gpio_set_value_cansleep(dev->firm_gpio, 0);
-		gpio_set_value_cansleep(dev->ven_gpio, 1);
+		if (dev->firm_gpio)
+			gpiod_set_value_cansleep(dev->firm_gpio, 0);
+		gpiod_set_value_cansleep(dev->ven_gpio, 1);
 		msleep(100);
 	}
 	else if (MODE_FW == mode) {
 		/* power on with firmware download (requires hw reset)
 		 */
 		pr_info("%s power on with firmware\n", __func__);
-		gpio_set_value(dev->ven_gpio, 1);
+		gpiod_set_value(dev->ven_gpio, 1);
 		msleep(20);
-		if (gpio_is_valid(dev->firm_gpio)) {
-			gpio_set_value(dev->firm_gpio, 1);
+		if (dev->firm_gpio) {
+			gpiod_set_value(dev->firm_gpio, 1);
 		}
 		else {
 			pr_err("%s Unused Firm GPIO %d\n", __func__, mode);
 			return GPIO_UNUSED;
 		}
 		msleep(20);
-		gpio_set_value(dev->ven_gpio, 0);
+		gpiod_set_value(dev->ven_gpio, 0);
 		msleep(100);
-		gpio_set_value(dev->ven_gpio, 1);
+		gpiod_set_value(dev->ven_gpio, 1);
 		msleep(20);
 	}
 	else {
@@ -189,9 +189,9 @@ static void pn544_disable(struct pn54x_dev *dev)
 {
 	/* power off */
 	pr_info("%s power off\n", __func__);
-	if (gpio_is_valid(dev->firm_gpio))
-		gpio_set_value_cansleep(dev->firm_gpio, 0);
-	gpio_set_value_cansleep(dev->ven_gpio, 0);
+	if (dev->firm_gpio)
+		gpiod_set_value_cansleep(dev->firm_gpio, 0);
+	gpiod_set_value_cansleep(dev->ven_gpio, 0);
 	msleep(100);
 
 	if(dev->sevdd_reg) regulator_disable(dev->sevdd_reg);
@@ -218,7 +218,7 @@ static ssize_t pn54x_dev_read(struct file *filp, char __user *buf,
 
 	mutex_lock(&pn54x_dev->read_mutex);
 
-	if (!gpio_get_value(pn54x_dev->irq_gpio)) {
+	if (!gpiod_get_value(pn54x_dev->irq_gpio)) {
 		if (filp->f_flags & O_NONBLOCK) {
 			ret = -EAGAIN;
 			goto fail;
@@ -236,7 +236,7 @@ static ssize_t pn54x_dev_read(struct file *filp, char __user *buf,
 			if (ret)
 				goto fail;
 
-			if (gpio_get_value(pn54x_dev->irq_gpio))
+			if (gpiod_get_value(pn54x_dev->irq_gpio))
 				break;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
@@ -366,8 +366,8 @@ static long  pn54x_dev_ioctl(struct file *filp, unsigned int cmd,
 		break;
 	case PN54X_CLK_REQ:
 		if(1 == arg){
-			if(gpio_is_valid(pn54x_dev->clkreq_gpio)){
-				gpio_set_value(pn54x_dev->clkreq_gpio, 1);
+			if(pn54x_dev->clkreq_gpio){
+				gpiod_set_value(pn54x_dev->clkreq_gpio, 1);
 			}
 			else {
 				pr_err("%s Unused Clkreq GPIO %lu\n", __func__, arg);
@@ -375,8 +375,8 @@ static long  pn54x_dev_ioctl(struct file *filp, unsigned int cmd,
 			}
 		}
 		else if(0 == arg) {
-			if(gpio_is_valid(pn54x_dev->clkreq_gpio)){
-				gpio_set_value(pn54x_dev->clkreq_gpio, 0);
+			if(pn54x_dev->clkreq_gpio){
+				gpiod_set_value(pn54x_dev->clkreq_gpio, 0);
 			}
 			else {
 				pr_err("%s Unused Clkreq GPIO %lu\n", __func__, arg);

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -468,29 +468,21 @@ static int pn54x_get_pdata_of(struct device *dev,
 	 * Example: if only PVdd is provided, it is the only one that will be
 	 *  turned on/off.
 	 */
-	pdata->pvdd_reg = regulator_get(dev, "nxp,pn54x-pvdd");
-	if(IS_ERR(pdata->pvdd_reg)) {
-		pr_err("%s: could not get nxp,pn54x-pvdd, rc=%ld\n", __func__, PTR_ERR(pdata->pvdd_reg));
+	pdata->pvdd_reg = devm_regulator_get_optional(dev, "nxp,pn54x-pvdd");
+	if (IS_ERR(pdata->pvdd_reg))
 		pdata->pvdd_reg = NULL;
-	}
 
-	pdata->vbat_reg = regulator_get(dev, "nxp,pn54x-vbat");
-	if (IS_ERR(pdata->vbat_reg)) {
-		pr_err("%s: could not get nxp,pn54x-vbat, rc=%ld\n", __func__, PTR_ERR(pdata->vbat_reg));
+	pdata->vbat_reg = devm_regulator_get_optional(dev, "nxp,pn54x-vbat");
+	if (IS_ERR(pdata->vbat_reg))
 		pdata->vbat_reg = NULL;
-	}
 
-	pdata->pmuvcc_reg = regulator_get(dev, "nxp,pn54x-pmuvcc");
-	if (IS_ERR(pdata->pmuvcc_reg)) {
-		pr_err("%s: could not get nxp,pn54x-pmuvcc, rc=%ld\n", __func__, PTR_ERR(pdata->pmuvcc_reg));
+	pdata->pmuvcc_reg = devm_regulator_get_optional(dev, "nxp,pn54x-pmuvcc");
+	if (IS_ERR(pdata->pmuvcc_reg))
 		pdata->pmuvcc_reg = NULL;
-	}
 
-	pdata->sevdd_reg = regulator_get(dev, "nxp,pn54x-sevdd");
-	if (IS_ERR(pdata->sevdd_reg)) {
-		pr_err("%s: could not get nxp,pn54x-sevdd, rc=%ld\n", __func__, PTR_ERR(pdata->sevdd_reg));
+	pdata->sevdd_reg = devm_regulator_get_optional(dev, "nxp,pn54x-sevdd");
+	if (IS_ERR(pdata->sevdd_reg))
 		pdata->sevdd_reg = NULL;
-	}
 
 	return 0;
 }

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -45,7 +45,6 @@
 
 /* Only pn548, pn547 and pn544 are supported */
 #define CHIP "pn544"
-#define DRIVER_CARD "PN54x NFC"
 #define DRIVER_DESC "NFC driver for PN54x Family"
 
 struct pn54x_dev	{
@@ -416,11 +415,10 @@ static int pn54x_get_pdata_of(struct device *dev,
 	/* firm pin - controls firmware download - OPTIONAL */
 	desc = devm_gpiod_get_optional(dev, "firmware", GPIOD_OUT_LOW);
 	if (IS_ERR(desc)) {
-		pdata->firm_gpio = NULL;
-		dev_warn(dev, "FIRM GPIO <OPTIONAL> error getting from OF node\n");
-	} else {
-		pdata->firm_gpio = desc;
+		dev_err(dev, "FIRM GPIO error getting from OF node\n");
+		return PTR_ERR(desc);
 	}
+	pdata->firm_gpio = desc;
 
 	/* irq pin - data available irq - REQUIRED */
 	desc = devm_gpiod_get(dev, "interrupt", GPIOD_IN);
@@ -433,11 +431,10 @@ static int pn54x_get_pdata_of(struct device *dev,
 	/* clkreq pin - controls the clock to the PN547 - OPTIONAL */
 	desc = devm_gpiod_get_optional(dev, "clkreq", GPIOD_OUT_LOW);
 	if (IS_ERR(desc)) {
-		pdata->clkreq_gpio = NULL;
-		dev_warn(dev, "CLKREQ GPIO <OPTIONAL> error getting from OF node\n");
-	} else {
-		pdata->clkreq_gpio = desc;
+		dev_err(dev, "CLKREQ GPIO error getting from OF node\n");
+		return PTR_ERR(desc);
 	}
+	pdata->clkreq_gpio = desc;
 
 	/* handle the regulator lines - these are optional
 	 * PVdd - pad Vdd (544, 547)

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -43,10 +43,6 @@
 
 #define MAX_BUFFER_SIZE	512
 
-#define MODE_OFF    0
-#define MODE_RUN    1
-#define MODE_FW     2
-
 /* Only pn548, pn547 and pn544 are supported */
 #define CHIP "pn544"
 #define DRIVER_CARD "PN54x NFC"
@@ -118,7 +114,7 @@ static int pn544_enable(struct pn54x_dev *dev, int mode)
 		r = regulator_enable(dev->vbat_reg);
 		if (r < 0){
 			pr_err("%s: not able to enable vbat\n", __func__);
-			goto enable_exit0;
+			goto err_vbat;
 		}
 	}
 	if(dev->pmuvcc_reg != NULL)
@@ -126,7 +122,7 @@ static int pn544_enable(struct pn54x_dev *dev, int mode)
 		r = regulator_enable(dev->pmuvcc_reg);
 		if (r < 0){
 			pr_err("%s: not able to enable pmuvcc\n", __func__);
-			goto enable_exit1;
+			goto err_pmuvcc;
 		}
 	}
 	if(dev->sevdd_reg != NULL)
@@ -134,48 +130,50 @@ static int pn544_enable(struct pn54x_dev *dev, int mode)
 		r = regulator_enable(dev->sevdd_reg);
 		if (r < 0){
 			pr_err("%s: not able to enable sevdd\n", __func__);
-			goto enable_exit2;
+			goto err_sevdd;
 		}
 	}
 
-	if (MODE_RUN == mode) {
+	if (PWR_ON == mode) {
 		pr_info("%s power on\n", __func__);
 		if (dev->firm_gpio)
 			gpiod_set_value_cansleep(dev->firm_gpio, 0);
 		gpiod_set_value_cansleep(dev->ven_gpio, 1);
 		msleep(100);
 	}
-	else if (MODE_FW == mode) {
+	else if (PWR_FW == mode) {
 		/* power on with firmware download (requires hw reset)
 		 */
 		pr_info("%s power on with firmware\n", __func__);
-		gpiod_set_value(dev->ven_gpio, 1);
-		msleep(20);
-		if (dev->firm_gpio) {
-			gpiod_set_value(dev->firm_gpio, 1);
-		}
-		else {
+		if (!dev->firm_gpio) {
 			pr_err("%s Unused Firm GPIO %d\n", __func__, mode);
-			return GPIO_UNUSED;
+			r = -EOPNOTSUPP;
+			goto err_gpio;
 		}
+		gpiod_set_value_cansleep(dev->ven_gpio, 1);
 		msleep(20);
-		gpiod_set_value(dev->ven_gpio, 0);
+		gpiod_set_value_cansleep(dev->firm_gpio, 1);
+		msleep(20);
+		gpiod_set_value_cansleep(dev->ven_gpio, 0);
 		msleep(100);
-		gpiod_set_value(dev->ven_gpio, 1);
+		gpiod_set_value_cansleep(dev->ven_gpio, 1);
 		msleep(20);
 	}
 	else {
 		pr_err("%s bad arg %d\n", __func__, mode);
-		return -EINVAL;
+		r = -EINVAL;
+		goto err_gpio;
 	}
 
 	return 0;
 
-enable_exit2:
+err_gpio:
+	if(dev->sevdd_reg) regulator_disable(dev->sevdd_reg);
+err_sevdd:
 	if(dev->pmuvcc_reg) regulator_disable(dev->pmuvcc_reg);
-enable_exit1:
+err_pmuvcc:
 	if(dev->vbat_reg) regulator_disable(dev->vbat_reg);
-enable_exit0:
+err_vbat:
 	if(dev->pvdd_reg) regulator_disable(dev->pvdd_reg);
 
 	return r;
@@ -214,7 +212,7 @@ static ssize_t pn54x_dev_read(struct file *filp, char __user *buf,
 
 	mutex_lock(&pn54x_dev->read_mutex);
 
-	if (!gpiod_get_value(pn54x_dev->irq_gpio)) {
+	if (!gpiod_get_value_cansleep(pn54x_dev->irq_gpio)) {
 		if (filp->f_flags & O_NONBLOCK) {
 			ret = -EAGAIN;
 			goto fail;
@@ -232,7 +230,7 @@ static ssize_t pn54x_dev_read(struct file *filp, char __user *buf,
 			if (ret)
 				goto fail;
 
-			if (gpiod_get_value(pn54x_dev->irq_gpio))
+			if (gpiod_get_value_cansleep(pn54x_dev->irq_gpio))
 				break;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
@@ -318,8 +316,6 @@ static int pn54x_dev_open(struct inode *inode, struct file *filp)
 
 	pr_info("%s : %d,%d\n", __func__, imajor(inode), iminor(inode));
 
-	// pn544_enable(pn54x_dev, MODE_RUN);
-
 	return 0;
 }
 
@@ -340,20 +336,16 @@ static long  pn54x_dev_ioctl(struct file *filp, unsigned int cmd,
 				unsigned long arg)
 {
 	struct pn54x_dev *pn54x_dev = filp->private_data;
+	int ret;
 
 	pr_info("%s, cmd=%d, arg=%lu\n", __func__, cmd, arg);
 	switch (cmd) {
 	case PN544_SET_PWR:
-		if (arg == 2) {
-			/* power on w/FW */
-			if (GPIO_UNUSED == pn544_enable(pn54x_dev, arg)) {
-				return GPIO_UNUSED;
-			}
-		} else if (arg == 1) {
-			/* power on */
-			pn544_enable(pn54x_dev, arg);
-		} else  if (arg == 0) {
-			/* power off */
+		if (arg == PWR_ON || arg == PWR_FW) {
+			ret = pn544_enable(pn54x_dev, arg);
+			if (ret)
+				return ret;
+		} else if (arg == PWR_OFF) {
 			pn544_disable(pn54x_dev);
 		} else {
 			pr_err("%s bad SET_PWR arg %lu\n", __func__, arg);
@@ -367,7 +359,7 @@ static long  pn54x_dev_ioctl(struct file *filp, unsigned int cmd,
 			}
 			else {
 				pr_err("%s Unused Clkreq GPIO %lu\n", __func__, arg);
-				return GPIO_UNUSED;
+				return -EOPNOTSUPP;
 			}
 		}
 		else if(0 == arg) {
@@ -376,7 +368,7 @@ static long  pn54x_dev_ioctl(struct file *filp, unsigned int cmd,
 			}
 			else {
 				pr_err("%s Unused Clkreq GPIO %lu\n", __func__, arg);
-				return GPIO_UNUSED;
+				return -EOPNOTSUPP;
 			}
 		} else {
 			pr_err("%s bad CLK_REQ arg %lu\n", __func__, arg);
@@ -539,7 +531,7 @@ static int pn54x_probe(struct i2c_client *client,
 static int pn54x_probe(struct i2c_client *client)
 #endif
 {
-	int ret;
+	int ret = 0;
 	struct pn544_i2c_platform_data *pdata; // gpio values, from board file or DT
 	struct pn544_i2c_platform_data tmp_pdata;
 	struct pn54x_dev *pn54x_dev; // internal device specific data
@@ -676,7 +668,7 @@ static void pn54x_remove(struct i2c_client *client)
 }
 
 #ifdef CONFIG_OF
-static struct of_device_id pn54x_dt_match[] = {
+static const struct of_device_id pn54x_dt_match[] = {
 	{ .compatible = "nxp,pn547", },
 	{ .compatible = "nxp,pn544", },
 	{},

--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -424,37 +424,37 @@ static int pn54x_get_pdata_of(struct device *dev,
 	memset(pdata, 0, sizeof(*pdata));
 
 	/* ven pin - enable's power to the chip - REQUIRED */
-	desc = devm_gpiod_get(dev, "enable", GPIOD_ASIS);
+	desc = devm_gpiod_get(dev, "enable", GPIOD_OUT_LOW);
 	if (IS_ERR(desc)) {
 		dev_err(dev, "VEN GPIO error getting from OF node\n");
 		return PTR_ERR(desc);
 	}
-	pdata->ven_gpio = desc_to_gpio(desc);
+	pdata->ven_gpio = desc;
 
 	/* firm pin - controls firmware download - OPTIONAL */
-	desc = devm_gpiod_get_optional(dev, "firmware", GPIOD_ASIS);
+	desc = devm_gpiod_get_optional(dev, "firmware", GPIOD_OUT_LOW);
 	if (IS_ERR(desc)) {
-		pdata->firm_gpio = GPIO_UNUSED;
+		pdata->firm_gpio = NULL;
 		dev_warn(dev, "FIRM GPIO <OPTIONAL> error getting from OF node\n");
 	} else {
-		pdata->firm_gpio = desc ? desc_to_gpio(desc) : GPIO_UNUSED;
+		pdata->firm_gpio = desc;
 	}
 
 	/* irq pin - data available irq - REQUIRED */
-	desc = devm_gpiod_get(dev, "interrupt", GPIOD_ASIS);
+	desc = devm_gpiod_get(dev, "interrupt", GPIOD_IN);
 	if (IS_ERR(desc)) {
 		dev_err(dev, "IRQ GPIO error getting from OF node\n");
 		return PTR_ERR(desc);
 	}
-	pdata->irq_gpio = desc_to_gpio(desc);
+	pdata->irq_gpio = desc;
 
 	/* clkreq pin - controls the clock to the PN547 - OPTIONAL */
-	desc = devm_gpiod_get_optional(dev, "clkreq", GPIOD_ASIS);
+	desc = devm_gpiod_get_optional(dev, "clkreq", GPIOD_OUT_LOW);
 	if (IS_ERR(desc)) {
-		pdata->clkreq_gpio = GPIO_UNUSED;
+		pdata->clkreq_gpio = NULL;
 		dev_warn(dev, "CLKREQ GPIO <OPTIONAL> error getting from OF node\n");
 	} else {
-		pdata->clkreq_gpio = desc ? desc_to_gpio(desc) : GPIO_UNUSED;
+		pdata->clkreq_gpio = desc;
 	}
 
 	/* handle the regulator lines - these are optional
@@ -657,37 +657,6 @@ static int pn54x_probe(struct i2c_client *client)
 	pn54x_dev->sevdd_reg = pdata->sevdd_reg;
 
 	pn54x_dev->client = client;
-
-	/* finish configuring the I/O */
-	ret = gpio_direction_input(pn54x_dev->irq_gpio);
-	if (ret < 0) {
-		pr_err("%s :not able to set irq_gpio as input\n", __func__);
-		goto err_exit;
-	}
-
-	ret = gpio_direction_output(pn54x_dev->ven_gpio, 0);
-	if (ret < 0) {
-		pr_err("%s : not able to set ven_gpio as output\n", __func__);
-		goto err_exit;
-	}
-
-	if (gpio_is_valid(pn54x_dev->firm_gpio)) {
-		ret = gpio_direction_output(pn54x_dev->firm_gpio, 0);
-		if (ret < 0) {
-			pr_err("%s : not able to set firm_gpio as output\n",
-				 __func__);
-			goto err_exit;
-		}
-	}
-
-	if (gpio_is_valid(pn54x_dev->clkreq_gpio)) {
-		ret = gpio_direction_output(pn54x_dev->clkreq_gpio, 0);
-		if (ret < 0) {
-			pr_err("%s : not able to set clkreq_gpio as output\n",
-				   __func__);
-			goto err_exit;
-		}
-	}
 
 	/* init mutex and queues */
 	init_waitqueue_head(&pn54x_dev->read_wq);

--- a/pn5xx_i2c.h
+++ b/pn5xx_i2c.h
@@ -38,11 +38,14 @@
 #define PN544_SET_PWR	_IOW(PN544_MAGIC, 0x01, unsigned int)
 #define PN54X_CLK_REQ	_IOW(PN544_MAGIC, 0x02, unsigned int)
 
+struct gpio_desc;
+struct regulator;
+
 struct pn544_i2c_platform_data {
-	unsigned int irq_gpio;
-	unsigned int ven_gpio;
-	unsigned int firm_gpio;
-	unsigned int clkreq_gpio;
+	struct gpio_desc *irq_gpio;
+	struct gpio_desc *ven_gpio;
+	struct gpio_desc *firm_gpio;
+	struct gpio_desc *clkreq_gpio;
 	struct regulator *pvdd_reg;
 	struct regulator *vbat_reg;
 	struct regulator *pmuvcc_reg;

--- a/pn5xx_i2c.h
+++ b/pn5xx_i2c.h
@@ -33,8 +33,6 @@
 #define CLK_OFF 0
 #define CLK_ON  1
 
-#define GPIO_UNUSED -1
-
 #define PN544_SET_PWR	_IOW(PN544_MAGIC, 0x01, unsigned int)
 #define PN54X_CLK_REQ	_IOW(PN544_MAGIC, 0x02, unsigned int)
 


### PR DESCRIPTION
Recently, Linux 7.1 removed `<linux/gpio.h>` and `<linux/of_gpio.h>` as well as the legacy integer GPIO API (`gpio_request`, `gpio_free`, `gpio_set_value`, etc.), causing this driver fail to build. In this PR I migrated to the descriptor-based `gpiod_*` API introduced around Linux 3.13 (I think).

GPIO lifetime is now managed by `devm_gpiod_get`, eliminating manual `gpio_request` and `gpio_free` calls in probe and remove. Direction is set at acquire using the `GPIOD_IN` and `GPIOD_OUT_LOW` flags. All GPIO reads and writes use `_cansleep`, which is fine since every GPIO access occurs in process context (ioctl, file ops), never in atomic or interrupt context. Also, this migration dramatically simplifies the Devicetree / ACPI split handling, and the GPIO setup and lifecycle management.

In addition, I configured the firmware download pin via ACPI as well, which was previously unconnected. This might be useful for firmware recovery / experiments via the HAL later on. I verified the pin map against the hardware DSDT and board schematics of my Yoga X1 Gen 3, now all three ACPI GPIO resources are treated as required due to the DSDT layout being fixed anyway.

In addition, I went over the code and did some general cleanup and bugfixes:

- Regulators were not disabled on error paths in `pn544_enable`
- `GPIO_UNUSED` (-1) leaked to userspace from ioctl, replaced it with a imho more useful `-EOPNOTSUPP`
- `ret` uninitialized in probe when neither ACPI nor DT path runs
- `pn544_enable` return value silently ignored for `PWR_ON` in ioctl
- `devm_gpiod_get_optional` errors silently swallowed as NULL in the DT path (a pin not specified is different from a pin specified but failing to init)
- More const correctness
- Missing `compat_ioctl` for 32-bit process support
- Remove unused includes, defines (`MODE_*`, `DRIVER_CARD`, `GPIO_UNUSED`), and commented-out code
- Use named constants (`PWR_*`, `CLK_*`) from the header instead of integer values
- Replace `//` comments with `/* */` (kernel style)

I also updated the README to provide a bit more help to new users.

Anyway, the driver works for me just as before, now on kernel 7.1.0:

```
Jun 23 20:30:06 redpulsar kernel: pn5xx_i2c: loading out-of-tree module taints kernel.
Jun 23 20:30:06 redpulsar kernel: pn54x_dev_init
Jun 23 20:30:06 redpulsar kernel: pn54x_probe
Jun 23 20:30:06 redpulsar kernel: pn54x_probe: configuring via ACPI
Jun 23 20:30:06 redpulsar kernel: pn54x_probe : requesting IRQ 197
Jun 23 20:30:32 redpulsar kernel: pn54x_dev_open : 10,263
Jun 23 20:30:32 redpulsar kernel: pn54x_dev_ioctl, cmd=1074063617, arg=1
Jun 23 20:30:32 redpulsar kernel: pn544_enable power on
Jun 23 20:30:32 redpulsar kernel: pn54x_dev_ioctl, cmd=1074063617, arg=0
Jun 23 20:30:32 redpulsar kernel: pn544_disable power off
Jun 23 20:30:33 redpulsar kernel: pn54x_dev_ioctl, cmd=1074063617, arg=1
Jun 23 20:30:33 redpulsar kernel: pn544_enable power on
```

In addition, I tested the driver via my PCSC IFD driver, KeePassXC with a NFC YubiKey, and the German ID card reading tool.

Open to suggestions if I missed something or something is unclear.